### PR TITLE
Mise en place de kafka connect vers le minio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM confluentinc/cp-kafka-connect:7.4.0
+
+# Installer le connecteur S3
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-s3:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,9 @@
 version: '3'
 
 services:
+  # =======================
+  # Zookeeper
+  # =======================
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
     container_name: zookeeper
@@ -10,39 +13,32 @@ services:
     ports:
       - "2181:2181"
 
-  schema-registry:
-    image: confluentinc/cp-schema-registry:latest
-    hostname: schema-registry
-    depends_on:
-      - kafka1
-      - kafka2
-    ports:
-      - "8081:8081"
-    environment:
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
-      SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka2:9092,PLAINTEXT_INTERNAL://localhost:29092
-      SCHEMA_REGISTRY_DEBUG: 'true'
-
+  # =======================
+  # Kafka Broker 1
+  # =======================
   kafka1:
     image: confluentinc/cp-kafka:latest
     hostname: kafka1
-    ports:
-      - "19092:19092"
+    container_name: kafka1
     depends_on:
       - zookeeper
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      # Pour exposer deux types de listeners, interne et externe
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092,PLAINTEXT_INTERNAL://localhost:19092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+    ports:
+      - "19092:19092"
+
+  # =======================
+  # Kafka Broker 2
+  # =======================
   kafka2:
     image: confluentinc/cp-kafka:latest
     hostname: kafka2
-    ports:
-      - "29092:29092"
+    container_name: kafka2
     depends_on:
       - zookeeper
     environment:
@@ -51,14 +47,38 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:9092,PLAINTEXT_INTERNAL://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+    ports:
+      - "29092:29092"
+
+  # =======================
+  # Schema Registry
+  # =======================
+  schema-registry:
+    image: confluentinc/cp-schema-registry:latest
+    container_name: schema-registry
+    hostname: schema-registry
+    depends_on:
+      - kafka1
+      - kafka2
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+      SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081
+      # On se connecte à kafka2, par ex. via PLAINTEXT://kafka2:9092
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka2:9092,PLAINTEXT_INTERNAL://localhost:29092
+      SCHEMA_REGISTRY_DEBUG: 'true'
+    ports:
+      - "8081:8081"
+
+  # =======================
+  # AKHQ (UI Web)
+  # =======================
   akhq:
     image: tchiotludo/akhq:latest
     container_name: akhq
     depends_on:
       - kafka1
       - kafka2
-    ports:
-      - "8080:8080"
     environment:
       AKHQ_CONFIGURATION: |
         akhq:
@@ -68,3 +88,70 @@ services:
                 bootstrap.servers: "kafka2:9092"
               schema-registry:
                 url: "http://schema-registry:8081"
+    ports:
+      - "8080:8080"
+
+  # =======================
+  # MinIO
+  # =======================
+  minio:
+    image: minio/minio
+    container_name: minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password123
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+
+  # =======================
+  # Kafka Connect
+  # =======================
+  kafka-connect:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: kafka-connect
+    depends_on:
+      - kafka1
+      - kafka2
+      - minio
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: "kafka1:9092,kafka2:9092"
+      CONNECT_GROUP_ID: "kafka-connect-group"
+      
+      # Topics internes
+      CONNECT_CONFIG_STORAGE_TOPIC: "_connect-configs"
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 2
+      CONNECT_OFFSET_STORAGE_TOPIC: "_connect-offsets"
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 2
+      CONNECT_STATUS_STORAGE_TOPIC: "_connect-status"
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 2
+
+      # Convertisseurs
+      CONNECT_KEY_CONVERTER: "io.confluent.connect.avro.AvroConverter"
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: "true"
+
+      CONNECT_VALUE_CONVERTER: "io.confluent.connect.avro.AvroConverter"
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: "true"
+
+
+      # Plugin path (pour le S3 Connector)
+      CONNECT_PLUGIN_PATH: "/usr/share/confluent-hub-components"
+
+      # REST
+      CONNECT_REST_ADVERTISED_HOST_NAME: kafka-connect
+      CONNECT_REST_PORT: 8083
+
+      # Log Level
+      CONNECT_LOG4J_LOGGERS: "org.reflections=ERROR"
+
+volumes:
+  minio-data:

--- a/merger/src/bin/main.rs
+++ b/merger/src/bin/main.rs
@@ -33,7 +33,7 @@ use tanit::{
 };
 
 use anyhow::Result;
-use tracing::info;
+use tracing::{info, warn};
 
 pub async fn start_subscriptions<F, C, P>(
     messaging: Arc<Kafka>,
@@ -71,7 +71,7 @@ where
             "cars",
             "merger",
             SubscriptionOptions {
-                offset: Offset::Latests,
+                offset: Offset::Beginning,
             },
             {
                 info!("listen to cars");
@@ -92,7 +92,7 @@ where
             "passengers",
             "merger",
             SubscriptionOptions {
-                offset: Offset::Latests,
+                offset: Offset::Beginning,
             },
             {
                 info!("listen to passenger");
@@ -150,7 +150,7 @@ async fn main() -> Result<()> {
     )
     .await?;
 
-    let server_config = HttpServerConfig::new("3333".to_string());
+    let server_config = HttpServerConfig::new("2222".to_string());
 
     let http_server = HttpServer::new(
         server_config,

--- a/producer/src/bin/main.rs
+++ b/producer/src/bin/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
 
     println!("Schemas created successfully");
 
-    let server_config = HttpServerConfig::new("3333".to_string());
+    let server_config = HttpServerConfig::new("2223".to_string());
     let http_server = HttpServer::new(server_config).await?;
 
     http_server.run().await?;

--- a/s3-parquet-connector.json
+++ b/s3-parquet-connector.json
@@ -1,0 +1,37 @@
+{
+    "name": "s3-parquet-connector",
+    "config": {
+      "connector.class": "io.confluent.connect.s3.S3SinkConnector",
+      "tasks.max": "1",
+      "topics": "ferries",
+      
+      "s3.bucket.name": "mon-bucket-minio",
+      "s3.region": "us-east-1",
+      "s3.part.size": "5242880",
+      
+      "store.url": "http://minio:9000",
+      "aws.access.key.id": "admin",
+      "aws.secret.access.key": "password123",
+      "s3.path.style.access": "true",
+  
+      "format.class": "io.confluent.connect.s3.format.parquet.ParquetFormat",
+  
+      "value.converter": "io.confluent.connect.avro.AvroConverter",
+      "value.converter.schemas.enable": "true",
+
+      "value.converter.schema.registry.url": "http://schema-registry:8081",
+      "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+      
+      "key.converter.schemas.enable": "false",
+      "storage.class": "io.confluent.connect.s3.storage.S3Storage",
+      "schema.generator.class": "io.confluent.connect.storage.hive.schema.DefaultSchemaGenerator",
+  
+      "flush.size": "1",
+      "rotate.interval.ms": "10000",
+  
+      "partitioner.class": "io.confluent.connect.storage.partitioner.DefaultPartitioner",
+      "locale": "fr-FR",
+      "timezone": "Europe/Paris"
+    }
+  }
+  

--- a/s3-parquet-connector.json
+++ b/s3-parquet-connector.json
@@ -3,7 +3,7 @@
     "config": {
       "connector.class": "io.confluent.connect.s3.S3SinkConnector",
       "tasks.max": "1",
-      "topics": "ferries",
+      "topics": "saver",
       
       "s3.bucket.name": "mon-bucket-minio",
       "s3.region": "us-east-1",
@@ -21,7 +21,7 @@
 
       "value.converter.schema.registry.url": "http://schema-registry:8081",
       "key.converter": "org.apache.kafka.connect.storage.StringConverter",
-      
+
       "key.converter.schemas.enable": "false",
       "storage.class": "io.confluent.connect.s3.storage.S3Storage",
       "schema.generator.class": "io.confluent.connect.storage.hive.schema.DefaultSchemaGenerator",


### PR DESCRIPTION
This pull request includes several changes to the Docker setup for a Kafka-based system, introducing new services and reorganizing existing ones. The most important changes are the addition of new services, the reorganization of the `docker-compose.yaml` file, and the setup of a new Kafka Connect S3 connector.

### New Services and Connectors:

* Added `minio` service to the `docker-compose.yaml` file, which includes configuration for ports, environment variables, and volumes.
* Added `kafka-connect` service to the `docker-compose.yaml` file, which includes configuration for building the Docker image, ports, and environment variables for Kafka Connect.
* Added `s3-parquet-connector.json` file, which includes the configuration for the S3 Parquet connector, specifying details like the S3 bucket, format class, and converters.

### Reorganization of `docker-compose.yaml`:

* Reorganized the `docker-compose.yaml` file by adding comments to clearly separate different services such as Zookeeper, Kafka brokers, Schema Registry, AKHQ, MinIO, and Kafka Connect. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R4-R6) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L13-R41) [[3]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R50-L61) [[4]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R91-R157)
* Moved the `schema-registry` service to a new section and adjusted its configuration.

### Dockerfile Changes:

* Updated the `Dockerfile` to use the `confluentinc/cp-kafka-connect:7.4.0` base image and installed the Kafka Connect S3 connector.